### PR TITLE
Implement custom queue adapter using Kafka

### DIFF
--- a/rails_app/Gemfile
+++ b/rails_app/Gemfile
@@ -30,6 +30,9 @@ gem "tzinfo-data", platforms: %i[ mingw mswin x64_mingw jruby ]
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", require: false
 
+# https://github.com/deadmanssnitch/kafka
+gem 'kafka', '~> 0.5.2'
+
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 

--- a/rails_app/Gemfile.lock
+++ b/rails_app/Gemfile.lock
@@ -76,6 +76,7 @@ GEM
       reline (>= 0.2.7)
     digest (3.1.0)
     erubi (1.10.0)
+    ffi (1.15.5)
     globalid (1.0.0)
       activesupport (>= 5.0)
     i18n (1.10.0)
@@ -83,6 +84,9 @@ GEM
     io-console (0.5.11)
     irb (1.4.1)
       reline (>= 0.3.0)
+    kafka (0.5.2)
+      ffi
+      mini_portile2
     loofah (2.18.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -91,6 +95,7 @@ GEM
     marcel (1.0.2)
     method_source (1.0.0)
     mini_mime (1.1.2)
+    mini_portile2 (2.8.0)
     minitest (5.15.0)
     msgpack (1.5.1)
     net-imap (0.2.3)
@@ -165,6 +170,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap
   debug
+  kafka (~> 0.5.2)
   puma (~> 5.0)
   rails (~> 7.0.3)
   sqlite3 (~> 1.4)

--- a/rails_app/app/lib/active_job/queue_adapters/kafka_adapter.rb
+++ b/rails_app/app/lib/active_job/queue_adapters/kafka_adapter.rb
@@ -1,0 +1,69 @@
+require "kafka"
+require "securerandom"
+
+module ActiveJob
+    module QueueAdapters
+        # == Active Job Kafka adapter
+        #
+        # The Kafka adapter runs jobs with the Kafka event streaming platform.
+        #
+        # This is a custom queue adapter. It needs a Kafka server
+        # configured and running.
+        #
+        # To use this adapter, set queue adapter to +:kafka+:
+        #
+        #   config.active_job.queue_adapter = :kafka
+        #
+        # To configure the adapter's Kafka servers, instantiate the adapter and
+        # pass your own config:
+        #
+        #   config.active_job.queue_adapter = ActiveJob::QueueAdapters::KafkaAdapter.new \
+        #     servers: ["redpanda", "localhost:9092"],
+        #
+        # The adapter uses a {kafka}[https://github.com/deadmanssnitch/kafka] client to produce jobs.
+        class KafkaAdapter
+            def initialize(**producer_options)
+                @producer = Producer.new(**producer_options)
+            end
+
+            def enqueue(job) # :nodoc:
+                self.enqueue_at(job, nil)
+            end
+
+            def enqueue_at(job, timestamp) # :nodoc:
+                @producer.produce JobWrapper.new(job), timestamp: timestamp, queue_name: job.queue_name
+            end
+
+            class JobWrapper # :nodoc:
+                def initialize(job)
+                    job.provider_job_id = SecureRandom.uuid
+                    @job_data           = job.serialize
+                end
+
+                def perform
+                    Base.execute @job_data
+                end
+
+                def data
+                    @job_data.to_json
+                end
+            end
+
+            class Producer # :nodoc:
+                DEFAULT_PRODUCER_OPTIONS = {
+                    servers: ENV.fetch('KAFKA_BROKERS')
+                }.freeze
+
+                def initialize(**producer_options)
+                    options         = DEFAULT_PRODUCER_OPTIONS.merge(producer_options)
+                    config          = Kafka::Config.new("bootstrap.servers": options[:servers])
+                    @kafka_producer = Kafka::Producer.new(config)
+                end
+
+                def produce(job, timestamp:, queue_name:)
+                    @kafka_producer.produce(queue_name, job.data, timestamp: timestamp)
+                end
+            end
+        end
+    end
+end


### PR DESCRIPTION
## Summary
To implement asynchronous email saving into database using the Rails tools and features, a Queue Adapter must be implemented within the `ActiveJob::QueueAdapters` module. It has to be placed under the `app/lib/active_job/queue_adapters` directory and to use the `kafka` gem to produce messages to a Kafka server.

## Test Plan
1. Started the application running the `docker compose up -d` command within the _rails_app_ directory.
2. Opened the _api_ service terminal running the `docker exec -it rails_app-api-1 /bin/bash` command.
3. Opened the Rails console running the `rails console` command.
4. Made sure the created adapter exists running the `ActiveJob::QueueAdapters.lookup(:kafka)` command within the Rails console and checking the output for the `ActiveJob::QueueAdapters::KafkaAdapter` message.
5. Made sure that looking for unexisting adapter returns error running the `ActiveJob::QueueAdapters.lookup(:wrong)` command and getting the `uninitialized constant ActiveJob::QueueAdapters::WrongAdapter (NameError)` output.