### PR TITLE
Add emails resource to the Rails application

### DIFF
--- a/rails_app/app/controllers/emails_controller.rb
+++ b/rails_app/app/controllers/emails_controller.rb
@@ -1,0 +1,51 @@
+class EmailsController < ApplicationController
+  before_action :set_email, only: %i[ show update destroy ]
+
+  # GET /emails
+  def index
+    @emails = Email.all
+
+    render json: @emails
+  end
+
+  # GET /emails/1
+  def show
+    render json: @email
+  end
+
+  # POST /emails
+  def create
+    @email = Email.new(email_params)
+
+    if @email.save
+      render json: @email, status: :created, location: @email
+    else
+      render json: @email.errors, status: :unprocessable_entity
+    end
+  end
+
+  # PATCH/PUT /emails/1
+  def update
+    if @email.update(email_params)
+      render json: @email
+    else
+      render json: @email.errors, status: :unprocessable_entity
+    end
+  end
+
+  # DELETE /emails/1
+  def destroy
+    @email.destroy
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_email
+      @email = Email.find(params[:id])
+    end
+
+    # Only allow a list of trusted parameters through.
+    def email_params
+      params.require(:email).permit(:address)
+    end
+end

--- a/rails_app/app/models/email.rb
+++ b/rails_app/app/models/email.rb
@@ -1,0 +1,2 @@
+class Email < ApplicationRecord
+end

--- a/rails_app/config/routes.rb
+++ b/rails_app/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  resources :emails
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Defines the root path route ("/")

--- a/rails_app/db/migrate/20220524181031_create_emails.rb
+++ b/rails_app/db/migrate/20220524181031_create_emails.rb
@@ -1,0 +1,9 @@
+class CreateEmails < ActiveRecord::Migration[7.0]
+  def change
+    create_table :emails do |t|
+      t.string :address, null: false, index: { name: 'emails_unique_address', unique: true }
+
+      t.timestamps
+    end
+  end
+end

--- a/rails_app/db/schema.rb
+++ b/rails_app/db/schema.rb
@@ -1,0 +1,21 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.0].define(version: 2022_05_24_181031) do
+  create_table "emails", force: :cascade do |t|
+    t.string "address", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["address"], name: "emails_unique_address", unique: true
+  end
+
+end

--- a/rails_app/test/controllers/emails_controller_test.rb
+++ b/rails_app/test/controllers/emails_controller_test.rb
@@ -1,0 +1,38 @@
+require "test_helper"
+
+class EmailsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @email = emails(:one)
+  end
+
+  test "should get index" do
+    get emails_url, as: :json
+    assert_response :success
+  end
+
+  test "should create email" do
+    assert_difference("Email.count") do
+      post emails_url, params: { email: { address: @email.address } }, as: :json
+    end
+
+    assert_response :created
+  end
+
+  test "should show email" do
+    get email_url(@email), as: :json
+    assert_response :success
+  end
+
+  test "should update email" do
+    patch email_url(@email), params: { email: { address: @email.address } }, as: :json
+    assert_response :success
+  end
+
+  test "should destroy email" do
+    assert_difference("Email.count", -1) do
+      delete email_url(@email), as: :json
+    end
+
+    assert_response :no_content
+  end
+end

--- a/rails_app/test/fixtures/emails.yml
+++ b/rails_app/test/fixtures/emails.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  address: test+1@example.com
+
+two:
+  address: test+2@example.com

--- a/rails_app/test/models/email_test.rb
+++ b/rails_app/test/models/email_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class EmailTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## Summary
To receive emails from users and save them to the database, emails resource must be generated. Add controller, route and model to the application running the `rails generate scaffold Email` command. Then run the migration:
- Start the application running the `docker compose up -d` command within the _rails_app_ directory.
- Open the _api_ service terminal running the `docker exec -it rails_app-api-1 /bin/bash` command.
- Run the `rails db:migrate` command.

## Test Plan
1. Started the application running the `docker compose up -d` command within the _rails_app_ directory.
2. Opened the _api_ service terminal running the `docker exec -it rails_app-api-1 /bin/bash` command.
3. Opened the Rails console running the `rails console` command.
4. Retrieved all emails from the database running the `Email.all` command within the console.
5. Made sure that the test email doesn't exist in the database yet running the `Email.find_by(address: 'test+1@example.com')` command and getting the `nil` within the output.
6. Created a new emails sending Post request to the http://localhost:3000/emails endpoint with the body:
```json
{
    "address": "test+1@example.com"
}
```
7. Made sure the email was successfully created.
8. Sent the same request again and made sure it was responded with the `UNIQUE constraint failed: emails.address` error.