### PR TITLE
Add job creating email

### DIFF
--- a/rails_app/app/controllers/emails_controller.rb
+++ b/rails_app/app/controllers/emails_controller.rb
@@ -15,13 +15,8 @@ class EmailsController < ApplicationController
 
   # POST /emails
   def create
-    @email = Email.new(email_params)
-
-    if @email.save
-      render json: @email, status: :created, location: @email
-    else
-      render json: @email.errors, status: :unprocessable_entity
-    end
+    CreateEmailRequestedJob.perform_later(email_params.to_json)
+    render status: :ok
   end
 
   # PATCH/PUT /emails/1

--- a/rails_app/app/jobs/create_email_requested_job.rb
+++ b/rails_app/app/jobs/create_email_requested_job.rb
@@ -1,0 +1,15 @@
+class CreateEmailRequestedJob < ApplicationJob
+  queue_as :create_email_requested
+
+  def perform(request_json)
+    request = JSON.parse(request_json, symbolize_names: true)
+    created = Email.new(request)
+
+    unless created.save
+      puts "FAILED inserting email: #{request}"
+      return
+    end
+
+    puts "created: #{created}"
+  end
+end

--- a/rails_app/config/application.rb
+++ b/rails_app/config/application.rb
@@ -23,5 +23,6 @@ module RailsApp
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
+    config.active_job.queue_name_prefix = Rails.env
   end
 end

--- a/rails_app/config/environments/development.rb
+++ b/rails_app/config/environments/development.rb
@@ -53,6 +53,7 @@ Rails.application.configure do
   # Highlight code that triggered database queries in logs.
   config.active_record.verbose_query_logs = true
 
+  config.active_job.queue_adapter = :kafka
 
   # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true

--- a/rails_app/test/jobs/create_email_requested_job_test.rb
+++ b/rails_app/test/jobs/create_email_requested_job_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class CreateEmailRequestedJobTest < ActiveJob::TestCase
+  setup do
+    @email = Email.new(address: 'test-from-job@example.com')
+  end
+
+  test "inserts email" do
+    assert_difference("Email.count") do
+      CreateEmailRequestedJob.perform_now(@email.to_json)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
To save emails asynchronously, a background job has to be implemented and integrated into the application.
Run the `rails generate job CreateEmailRequested` command to generate the job. Implement it's _perform_ method to save emails received from clients.

## Test Plan
1. Started the application running the `docker compose up -d` command within the _rails_app_ directory.
2. Opened the _redpanda_ service terminal running the `docker exec -it rails_app-redpanda-1 /bin/bash` command.
3. Subscribed to the _development_create_email_requested_ topic running the `rpk topic consume development_create_email_requested` command.
4. Created a new email sending Post request to the http://localhost:3000/emails endpoint with the body:
```json
{
    "address": "test+1@example.com"
}
```
5. Made sure the _redpanda_ terminal output contains serialized job as a message.